### PR TITLE
Allow empty string in options type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "storyblok-generate-ts",
-  "version": "1.0.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.1",
+      "name": "storyblok-generate-ts",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "camelcase": "^6.2.0",
@@ -318,9 +319,9 @@
       }
     },
     "node_modules/json-schema-to-typescript": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-10.1.4.tgz",
-      "integrity": "sha512-HWm23Z6Fnj3rnm4FKZh3sMz70hNoA+AfqVuV+ZcwFIhq6v76YVUMZSLlonrw7GI5yIoiuuJjB5rqakIYRCLlsg==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-10.1.5.tgz",
+      "integrity": "sha512-X8bNNksfCQo6LhEuqNxmZr4eZpPjXZajmimciuk8eWXzZlif9Brq7WuMGD/SOhBKcRKP2SGVDNZbC28WQqx9Rg==",
       "dependencies": {
         "@types/json-schema": "^7.0.6",
         "@types/lodash": "^4.14.168",
@@ -768,9 +769,9 @@
       }
     },
     "json-schema-to-typescript": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-10.1.4.tgz",
-      "integrity": "sha512-HWm23Z6Fnj3rnm4FKZh3sMz70hNoA+AfqVuV+ZcwFIhq6v76YVUMZSLlonrw7GI5yIoiuuJjB5rqakIYRCLlsg==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-10.1.5.tgz",
+      "integrity": "sha512-X8bNNksfCQo6LhEuqNxmZr4eZpPjXZajmimciuk8eWXzZlif9Brq7WuMGD/SOhBKcRKP2SGVDNZbC28WQqx9Rg==",
       "requires": {
         "@types/json-schema": "^7.0.6",
         "@types/lodash": "^4.14.168",

--- a/src/index.js
+++ b/src/index.js
@@ -211,6 +211,9 @@ module.exports = function storyblokToTypescript ({
       }
       if (schemaElement.options && schemaElement.options.length) {
         const items = schemaElement.options.map(item => item.value)
+        if (schemaElement.exclude_empty_option !== true) {
+          items.unshift('')
+        }
         if (schemaType === 'string') {
           obj[key].enum = items
         } else {


### PR DESCRIPTION
Hey, thanks for the really helpful tool.

In Storyblok, you can define a type with options e.g.

```
Name: background_color

Type: Single-Option

Options (name/value):
Blue/blue
Green/green
```

`storyblok-generate-ts` will generate the following type for this:

`background_color?: "blue" | "green"`

However, by default, Storyblok will allow this property to be set to an empty option, which means we would really want the type:

`background_color?: "" | "blue" | "green"`

(This behavior can be changed by checking the `Hide empty option` checkbox.)

This PR  adds the empty option (if appropraite) for types with options.
