### PR TITLE
Remove duplicated typings

### DIFF
--- a/src/standardTypes.js
+++ b/src/standardTypes.js
@@ -1,0 +1,163 @@
+const {compile} = require("json-schema-to-typescript");
+const typeFuncs = {
+  'asset': generateAssetTypeIfNotYetGenerated,
+  'multiasset': generateMultiAssetTypeIfNotYetGenerated,
+  'multilink': generateMultiLinkTypeIfNotYetGenerated
+}
+const toGenerateWhitelist = Object.keys(typeFuncs)
+
+async function compileType(obj, name) {
+  const ts = await compile(obj, name, {
+    unknownAny: false,
+    bannerComment: '',
+    unreachableDefinitions: true
+  })
+  toGenerateWhitelist.splice(toGenerateWhitelist.indexOf(name), 1)
+  return ts
+}
+
+async function generate(type, title){
+  return await typeFuncs[type](title)
+}
+
+async function generateAssetTypeIfNotYetGenerated(title) {
+  if (!toGenerateWhitelist.includes("asset")) return;
+  const obj = {}
+  obj.$id = '#/' + 'asset'
+  obj.title = title
+  obj.type = 'object'
+  obj.required = ['id', 'filename', 'name']
+  obj.properties = {
+    alt: {
+      type: 'string'
+    },
+    copyright: {
+      type: 'string'
+    },
+    id: {
+      type: 'number'
+    },
+    filename: {
+      type: 'string'
+    },
+    name: {
+      type: 'string'
+    },
+    title: {
+      type: 'string'
+    }
+  }
+  try {
+    return await compileType(obj, "asset")
+  } catch (e) {
+    console.log('ERROR', e)
+  }
+}
+
+async function generateMultiAssetTypeIfNotYetGenerated(title) {
+  if (!toGenerateWhitelist.includes("multiasset")) return;
+  const obj = {}
+  obj.$id = '#/' + 'multiasset'
+  obj.title = title
+  obj.type = 'array'
+  obj.items = {
+    type: 'object',
+    required: ['id', 'filename', 'name'],
+    properties: {
+      alt: {
+        type: 'string'
+      },
+      copyright: {
+        type: 'string'
+      },
+      id: {
+        type: 'number'
+      },
+      filename: {
+        type: 'string'
+      },
+      name: {
+        type: 'string'
+      },
+      title: {
+        type: 'string'
+      }
+    }
+  }
+  try {
+    return await compileType(obj, "multiasset")
+  } catch (e) {
+    console.log('ERROR', e)
+  }
+}
+
+async function generateMultiLinkTypeIfNotYetGenerated(title) {
+  if (!toGenerateWhitelist.includes("multilink")) return;
+  const obj = {
+    'oneOf': [
+      {
+        type: 'object',
+        properties: {
+          cached_url: {
+            type: 'string'
+          },
+          linktype: {
+            type: 'string'
+          }
+        }
+      },
+      {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string'
+          },
+          cached_url: {
+            type: 'string'
+          },
+          linktype: {
+            type: 'string',
+            enum: ['story']
+          }
+        }
+      },
+      {
+        type: 'object',
+        properties: {
+          url: {
+            type: 'string'
+          },
+          cached_url: {
+            type: 'string'
+          },
+          linktype: {
+            type: 'string',
+            enum: ['asset', 'url']
+          }
+        }
+      },
+      {
+        type: 'object',
+        properties: {
+          email: {
+            type: 'string'
+          },
+          linktype: {
+            type: 'string',
+            enum: ['email']
+          }
+        }
+      }
+    ]
+  }
+  try {
+    return await compileType(obj, title)
+  } catch (e) {
+    console.log('ERROR', e)
+  }
+}
+
+module.exports = {
+  TYPES: Object.keys(typeFuncs),
+  generate
+}


### PR DESCRIPTION
### Remove duplicated typings
Resolves #9
-------
For the standard types 
- asset
- multiasset
-  multilink

An extra interface/type is now generated on demand and used instead of duplicating each object on a component.

```
export interface AssetStoryblok {
  alt?: string;
  copyright?: string;
  id: number;
  filename: string;
  name: string;
  title?: string;
  [k: string]: any;
}

export type MultiassetStoryblok = {
  alt?: string;
  copyright?: string;
  id: number;
  filename: string;
  name: string;
  title?: string;
  [k: string]: any;
}[];

export type MultilinkStoryblok =
  | {
      cached_url?: string;
      linktype?: string;
      [k: string]: any;
    }
  | {
      id?: string;
      cached_url?: string;
      linktype?: "story";
      [k: string]: any;
    }
  | {
      url?: string;
      cached_url?: string;
      linktype?: "asset" | "url";
      [k: string]: any;
    }
  | {
      email?: string;
      linktype?: "email";
      [k: string]: any;
    };
```
