### PR TITLE
add compilerOptions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # storyblok-generate-ts
-This plugin uses `json-schema-to-typescript` to generate TS types based on `Storyblok` components. 
+This plugin uses [json-schema-to-typescript](https://github.com/bcherny/json-schema-to-typescript) to generate TS types based on `Storyblok` components. 
 You can install and run it as a CLI script
 
 ### 1. Prepare the use of this script
@@ -24,6 +24,7 @@ $ npm install -D storyblok-generate-ts
 - target *optional default: storyblok-component-types.d.ts
 - titlePrefix *optional default: '_storyblok' 
 - titleSuffix *optional
+- compilerOptions.[property] *optional
 - customTypeParser *optional - path to a custom parser NodeJS file
 ```
 
@@ -42,6 +43,12 @@ storyblokToTypescript({
   titlePrefix: '',
   // optional type name suffix (default: [Name]_Storyblok)
   titleSuffix: '_storyblok',
+  // optional compilerOptions which get passed through to json-schema-to-typescript
+  compilerOptions: {
+    unknownAny: false,
+    bannerComment: '',
+    unreachableDefinitions: true
+  }
   // optional function for custom types (key, obj) => {}
   // customTypeParser: exampleCustomParser
 })
@@ -124,3 +131,4 @@ type PageWithRelations = PageStoryblok & {
 * 1.5.0 De-Duplicate asset, multiasset and multilink (thanks to @markus-gx)
 * 1.6.0 Add table schema (thanks to @markus-gx)
 * 1.6.1 Add asset focus type (thanks to @markus-gx)
+* 1.7.0 Add compilerOptions option (thanks to @SassNinja)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storyblok-generate-ts",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Generates TypeScript types based on component file",
   "main": "src/index.js",
   "repository": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,10 +3,26 @@ const storyblokToTypescript = require('./index')
 const {resolve} = require('path')
 const [, , ...args] = process.argv
 
+const parseValue = (value) => {
+  if (value.match(/^(true|false)$/)) {
+      return value === 'true'
+  }
+  if (value.match(/^[\d.]+$/)) {
+    return Number(value)
+  }
+  return value
+}
+
 const props = {}
 args.forEach(key => {
   const [name, value] = key.split('=').map(i => i.trim())
-  props[name] = value
+  if (name.match(/\w+\.\w+/)) {
+    const [objectName, objectProperty] = name.split('.');
+    props[objectName] = props[objectName] || {};
+    props[objectName][objectProperty] = parseValue(value);
+  } else {
+    props[name] = parseValue(value)
+  }
 })
 if (!props.source) {
   console.log('there is no source path to components file')
@@ -19,6 +35,7 @@ if (props.target && !props.target.endsWith('.ts')) {
 
 const options = {
   componentsJson: require(resolve(props.source)),
+  compilerOptions: props.compilerOptions || {},
   path: resolve(props.target || './storyblok-component-types.d.ts')
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,18 @@ module.exports = function storyblokToTypescript({
                                                   componentsJson = {components: []},
                                                   customTypeParser = () => {
                                                   },
+                                                  compilerOptions = {},
                                                   path = 'src/typings/generated/components-schema.ts',
                                                   titleSuffix = '_storyblok',
                                                   titlePrefix = ''
                                                 }) {
+  
+  compilerOptions = Object.assign({
+    unknownAny: false,
+    bannerComment: '',
+    unreachableDefinitions: true
+  }, compilerOptions)
+  
   let tsString = []
   const getTitle = (t) => titlePrefix + t + titleSuffix
 
@@ -58,11 +66,7 @@ module.exports = function storyblokToTypescript({
         obj.required = requiredFields
       }
       try {
-        const ts = await compile(obj, values.name, {
-          unknownAny: false,
-          bannerComment: '',
-          unreachableDefinitions: true
-        })
+        const ts = await compile(obj, values.name, compilerOptions)
         tsString.push(ts)
       } catch (e) {
         console.log('ERROR', e)
@@ -77,7 +81,7 @@ module.exports = function storyblokToTypescript({
       const schemaElement = schema[key]
       const type = schemaElement.type
       if(standardTypes.TYPES.includes(type)){
-        const ts = await standardTypes.generate(type,getTitle(type))
+        const ts = await standardTypes.generate(type,getTitle(type),compilerOptions)
         tsString.push(ts)
       }
       else if (type === 'custom') {

--- a/src/standardTypes.js
+++ b/src/standardTypes.js
@@ -7,21 +7,17 @@ const typeFuncs = {
 }
 const toGenerateWhitelist = Object.keys(typeFuncs)
 
-async function compileType(obj, name) {
-  const ts = await compile(obj, name, {
-    unknownAny: false,
-    bannerComment: '',
-    unreachableDefinitions: true
-  })
+async function compileType(obj, name, compilerOptions) {
+  const ts = await compile(obj, name, compilerOptions);
   toGenerateWhitelist.splice(toGenerateWhitelist.indexOf(name), 1)
   return ts
 }
 
-async function generate(type, title){
-  return await typeFuncs[type](title)
+async function generate(type, title, compilerOptions){
+  return await typeFuncs[type](title, compilerOptions)
 }
 
-async function generateAssetTypeIfNotYetGenerated(title) {
+async function generateAssetTypeIfNotYetGenerated(title, compilerOptions) {
   if (!toGenerateWhitelist.includes("asset")) return;
   const obj = {}
   obj.$id = '#/' + 'asset'
@@ -52,13 +48,13 @@ async function generateAssetTypeIfNotYetGenerated(title) {
     }
   }
   try {
-    return await compileType(obj, "asset")
+    return await compileType(obj, "asset", compilerOptions)
   } catch (e) {
     console.log('ERROR', e)
   }
 }
 
-async function generateMultiAssetTypeIfNotYetGenerated(title) {
+async function generateMultiAssetTypeIfNotYetGenerated(title, compilerOptions) {
   if (!toGenerateWhitelist.includes("multiasset")) return;
   const obj = {}
   obj.$id = '#/' + 'multiasset'
@@ -89,13 +85,13 @@ async function generateMultiAssetTypeIfNotYetGenerated(title) {
     }
   }
   try {
-    return await compileType(obj, "multiasset")
+    return await compileType(obj, "multiasset", compilerOptions)
   } catch (e) {
     console.log('ERROR', e)
   }
 }
 
-async function generateMultiLinkTypeIfNotYetGenerated(title) {
+async function generateMultiLinkTypeIfNotYetGenerated(title, compilerOptions) {
   if (!toGenerateWhitelist.includes("multilink")) return;
   const obj = {
     'oneOf': [
@@ -157,13 +153,13 @@ async function generateMultiLinkTypeIfNotYetGenerated(title) {
   obj.$id = '#/' + 'multilink'
   obj.title = title
   try {
-    return await compileType(obj, "multilink")
+    return await compileType(obj, "multilink", compilerOptions)
   } catch (e) {
     console.log('ERROR', e)
   }
 }
 
-async function generateTableTypeIfNotYetGenerated(title) {
+async function generateTableTypeIfNotYetGenerated(title, compilerOptions) {
   if (!toGenerateWhitelist.includes("table")) return;
   const obj = {}
   obj.$id = '#/' + 'table'
@@ -223,7 +219,7 @@ async function generateTableTypeIfNotYetGenerated(title) {
     }
   }
   try {
-    return await compileType(obj, "table")
+    return await compileType(obj, "table", compilerOptions)
   } catch (e) {
     console.log('ERROR', e)
   }


### PR DESCRIPTION
I've added a new option to customise the options used for the underlying json-schema-to-typescript package. Prior to this change it was hard coded without the possibility to override it.

In the course of this I've also introduced a `parseValue` util in the cli module because string-only is not sufficient for customising the options via args.

This PR closes https://github.com/dohomi/storyblok-generate-ts/issues/13 