### PR TITLE
Fixes an error when filter_content_type is not an array.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -194,8 +194,14 @@ export default async function storyblokToTypescript({
 
         if (element.source === "internal_stories" && element.filter_content_type) {
             if (element.type === "option") {
-                return {
-                    tsType: `(${getStoryTypeTitle(element.filter_content_type[0])} | string )`,
+                if(Array.isArray(element.filter_content_type)){
+                    return {
+                        tsType: `(${getStoryTypeTitle(element.filter_content_type[0])} | string )`,
+                    }
+                } else {
+                    return {
+                        tsType: `(${getStoryTypeTitle(element.filter_content_type)} | string )`,
+                    }
                 }
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,8 +200,14 @@ export default async function storyblokToTypescript({
             }
 
             if (element.type === "options") {
-                return {
-                    tsType: `(${element.filter_content_type.map(type => getStoryTypeTitle(type)).join(" | ")} | string )[]`
+                if(Array.isArray(element.filter_content_type)){
+                    return {
+                        tsType: `(${element.filter_content_type.map((type2) => getStoryTypeTitle(type2)).join(" | ")} | string )[]`
+                    };
+                } else {
+                    return {
+                        tsType: `(${getStoryTypeTitle(element.filter_content_type)} | string )[]`
+                    }
                 }
             }
 


### PR DESCRIPTION
fixes #28 
Took the liberty of creating a PR containing the patched code I had to add. I will leave it to your consideration if this can be merged. 
Let me know If you require anything to help move this forward.

produces the following type as an example:

```typescript
export interface FeaturedProductsStoryblok {
  title?: string;
  products?: (StoryblokStory<ProductStoryblok> | string)[];
  _uid: string;
  component: "featured_products";
  [k: string]: any;
}
```

PD: there are probaly shorthands to write the code for this but I wanted to be verbose to be extra clear and readable
