### PR TITLE
[hotfix] Update types for `StoryblokStory`

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -74,13 +74,13 @@ export interface StoryblokStory<TContent> {
     position: number
     tag_list: string[]
     is_startpage: boolean;
-    parent_id: string
+    parent_id: number;
     meta_data: any;
     group_id: string
     first_published_at: string | null;
     release_id?: number | null;
     lang: string;
-    path: string | null
+    path?: string;
     alternates: {
         id: number;
         name: string;


### PR DESCRIPTION
### Issue
When using `useStoryblokState`, the hook expects story to have types of `ISbStoryData` which definition you can find in storyblok-js-client package in `storyblok-js-client/dist/types/interfaces.d.ts`. And `StoryblokStory` deviates in only 2 properties: `parent_id` and `paths`.

### Quick Solution 
We do what I did in this PR.

### Better (?) Solution
We install storyblok-js-client and `extends` `ISbStoryData` interface. 🤷 