### PR TITLE
fix dohomi/storyblok-generate-ts#47

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,11 +84,11 @@ getDataFromPath(props.source).then((rawComponents) => {
         path: resolve(props.target || './storyblok-component-types.d.ts')
     }
     
-    if (props.titlePrefix) {
+    if (props.titlePrefix !== undefined) {
         options.titlePrefix = props.titlePrefix
     }
     
-    if (props.titleSuffix) {
+    if (props.titleSuffix !== undefined) {
         options.titleSuffix = props.titleSuffix
     }
     

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -96,8 +96,8 @@ describe("storyblokToTypescript", () => {
         });
         const mainType = prepareString(types[2]);
         const expectation = makeExpectString(`
-            myField?:number;
-            myRequiredField:number;
+            myField?:string;
+            myRequiredField:string;
         `);
 
         expect(mainType).toBe(expectation);
@@ -363,5 +363,26 @@ describe("storyblokToTypescript", () => {
     }`);
         expect(tableType).toBe(tableTypeExpect);
         expect(mainType).toBe(mainTypeExpect);
+    });
+
+    test("Should allow empty suffix", async () => {
+        const types = await storyblokToTypescript({
+            componentsJson: makeSBComponent({
+                title: { type: "text" },
+                requiredTitle: { type: "text", required: true },
+            }),
+            titleSuffix: "",
+        });
+        const mainType = prepareString(types[2]);
+
+        const expectation = prepareString(`export interface ResourceName {
+            title?: string;
+            requiredTitle: string;
+            _uid: string;
+            component: "ResourceName";
+            [k: string]: any;
+          }`);
+
+        expect(mainType).toBe(expectation);
     });
 });


### PR DESCRIPTION
Allow empty string for titleSuffix in CLI