### PR TITLE
feat add basic blok information if not specified

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,7 +15,7 @@ const makeSBComponent = (schema: Record<string, any>) => ({
 const prepareString = (str: string) => str.replace(/\s/g, "").trim();
 
 const makeExpectString = (str: string) =>
-    prepareString(`export interface ResourceNameStoryblok { 
+    prepareString(`export interface ResourceNameStoryblok {
   ${str}
   _uid: string;
   component: "ResourceName";
@@ -80,8 +80,8 @@ describe("storyblokToTypescript", () => {
         });
         const mainType = prepareString(types[2]);
         const expectation = makeExpectString(`
-            myField?:any[];
-            myRequiredField:any[];
+            myField?:{_uid:string;[k:string]:any;}[];
+            myRequiredField:{_uid:string;[k:string]:any;}[];
         `);
 
         expect(mainType).toBe(expectation);
@@ -96,8 +96,8 @@ describe("storyblokToTypescript", () => {
         });
         const mainType = prepareString(types[2]);
         const expectation = makeExpectString(`
-            myField?:number;
-            myRequiredField:number;
+            myField?:string;
+            myRequiredField:string;
         `);
 
         expect(mainType).toBe(expectation);
@@ -144,7 +144,7 @@ describe("storyblokToTypescript", () => {
         });
 
         const richtextType = prepareString(types[2])
-        const mainType =  prepareString(types[3]);
+        const mainType = prepareString(types[3]);
 
         const richtextTypeExpect = prepareString(`export interface RichtextStoryblok {
             type: string;
@@ -192,7 +192,7 @@ describe("storyblokToTypescript", () => {
             }),
         });
         const assetType = prepareString(types[2])
-        const mainType =  prepareString(types[3]);
+        const mainType = prepareString(types[3]);
 
         const assetTypeExpect = prepareString(`export interface AssetStoryblok {
             alt?: string;
@@ -299,8 +299,8 @@ describe("storyblokToTypescript", () => {
             }),
         });
 
-        const assetType =  prepareString(types[2]);
-        const mainType =  prepareString(types[3]);
+        const assetType = prepareString(types[2]);
+        const mainType = prepareString(types[3]);
 
         const assetTypeExpect =
             prepareString(`export type MultiassetStoryblok = {
@@ -329,8 +329,8 @@ describe("storyblokToTypescript", () => {
             }),
         });
 
-        const tableType =  prepareString(types[2]);
-        const mainType =  prepareString(types[3]);
+        const tableType = prepareString(types[2]);
+        const mainType = prepareString(types[3]);
 
         const tableTypeExpect = prepareString(`export interface TableStoryblok {
       thead: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,7 +266,18 @@ export default async function storyblokToTypescript({
             case 'text':
                 return {type: 'string'}
             case 'bloks':
-                return {type: 'array'}
+                return {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        required: ['_uid'],
+                        properties: {
+                            _uid: {
+                                type: 'string'
+                            }
+                        }
+                    }
+                }
             case 'number':
                 return {type: 'string'}
             case 'image':


### PR DESCRIPTION
Adds default `_uid` field to unknown bloks. This is useful for blok iterations, e.g.

```
export default function Grid({ blok }: { blok: GridStoryblok }) {
  return (
    <div className="grid grid-cols-3" {...storyblokEditable(blok)}>
      {blok.columns?.map((nestedBlok) => (
        <StoryblokComponent blok={nestedBlok} key={nestedBlok._uid} />
      ))}
    </div>
  );
}
```

Otherwise `_uid` has to be typed if used with `unknownAny=true`.