### PR TITLE
Better typing when there are no component restrictions

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -80,8 +80,8 @@ describe("storyblokToTypescript", () => {
         });
         const mainType = prepareString(types[2]);
         const expectation = makeExpectString(`
-            myField?:any[];
-            myRequiredField:any[];
+            myField?:ResourceNameStoryblok[];
+            myRequiredField:ResourceNameStoryblok[];
         `);
 
         expect(mainType).toBe(expectation);

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,16 +31,20 @@ export default async function storyblokToTypescript({
     const getStoryTypeTitle = (t: string) => `StoryblokStory<${camelcase(getTitle(t), {pascalCase: true})}>`
 
     const groupUuids: { [k: string]: JSONSchema4 } = {}
+    const allComponents: string[] = []
 
     componentsJson.components.forEach(value => {
+        const componentName = camelcase(getTitle(value.name), {
+            pascalCase: true
+        })
         if (value.component_group_uuid) {
             if (!groupUuids[value.component_group_uuid]) {
                 groupUuids[value.component_group_uuid] = []
             }
-            groupUuids[value.component_group_uuid].push(camelcase(getTitle(value.name), {
-                pascalCase: true
-            }))
+            groupUuids[value.component_group_uuid].push(componentName)
         }
+
+        allComponents.push(componentName)
     })
 
     async function genTsSchema() {
@@ -152,6 +156,7 @@ export default async function storyblokToTypescript({
                     }
                 } else {
                     console.log('Type: bloks array but not whitelisted (will result in all elements):', title)
+                    obj[key].tsType = `(${allComponents.join(' | ')})[]`
                 }
             }
             Object.assign(parseObj, obj)


### PR DESCRIPTION
Currently, when there is no restriction on a component field, the field is typed as `any[]`. This change makes the typing more specific by making it a union of the possible components. e.g. `(SbVideo | SbImage | SbSlideshow)[]`