### PR TITLE
Stricter multilink typing

### DIFF
--- a/src/genericTypes.ts
+++ b/src/genericTypes.ts
@@ -148,17 +148,6 @@ async function generateMultiLinkTypeIfNotYetGenerated(title: string, compilerOpt
             {
                 type: 'object',
                 properties: {
-                    cached_url: {
-                        type: 'string'
-                    },
-                    linktype: {
-                        type: 'string'
-                    }
-                }
-            },
-            {
-                type: 'object',
-                properties: {
                     id: {
                         type: 'string'
                     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,22 @@ export default async function storyblokToTypescript({
 
             obj[key] = element
 
-            if (TYPES.includes(type)) {
+            if (type === 'multilink') {
+                const excludedLinktypes = [];
+                const baseType = camelcase(getTitle(type), {
+                    pascalCase: true
+                })
+
+                if (!schemaElement.email_link_type) {
+                    excludedLinktypes.push('{ linktype?: "email" }');
+                }
+                if (!schemaElement.asset_link_type) {
+                    excludedLinktypes.push('{ linktype?: "asset" }');
+                }
+
+                obj[key].tsType = excludedLinktypes.length ?
+                    `Exclude<${baseType}, ${excludedLinktypes.join(' | ')}>` : baseType
+            } else if (TYPES.includes(type)) {
                 obj[key].tsType = camelcase(getTitle(type), {
                     pascalCase: true
                 })


### PR DESCRIPTION
This change enables more specific typing of multi-link items by reading the schema properties and excluding the link types which do not apply. 