### PR TITLE
Add target property to MultiLinkType

### DIFF
--- a/src/genericTypes.ts
+++ b/src/genericTypes.ts
@@ -161,6 +161,10 @@ async function generateMultiLinkTypeIfNotYetGenerated(title: string, compilerOpt
                         type: 'string',
                         enum: ['story']
                     },
+                    target: {
+                        type: 'string',
+                        enum: ['_self', '_blank'],
+                    },
                     story: {
                         type: 'object',
                         required: ['name', 'id', 'uuid', 'slug', 'full_slug'],
@@ -259,7 +263,11 @@ async function generateMultiLinkTypeIfNotYetGenerated(title: string, compilerOpt
                     linktype: {
                         type: 'string',
                         enum: ['asset', 'url']
-                    }
+                    },
+                    target: {
+                        type: 'string',
+                        enum: ['_self', '_blank'],
+                    },
                 }
             },
             {
@@ -271,7 +279,11 @@ async function generateMultiLinkTypeIfNotYetGenerated(title: string, compilerOpt
                     linktype: {
                         type: 'string',
                         enum: ['email']
-                    }
+                    },
+                    target: {
+                        type: 'string',
+                        enum: ['_self', '_blank'],
+                    },
                 }
             }
         ]


### PR DESCRIPTION
Adds a target property to all union members of the MultiLink type. This field exists for all link types in the CMS if you mark "Allow links to be open in a new tab".

Related issue: https://github.com/dohomi/storyblok-generate-ts/issues/59

Output:

```Typescript
export type MultilinkStoryblok =
  | {
      id?: string;
      cached_url?: string;
      anchor?: string;
      linktype?: "story";
      target?: "_self" | "_blank";
      story?: {
        name: string;
        created_at?: string;
        published_at?: string;
        id: number;
        uuid: string;
        content?: {
          [k: string]: any;
        };
        slug: string;
        full_slug: string;
        sort_by_date?: null | string;
        position?: number;
        tag_list?: string[];
        is_startpage?: boolean;
        parent_id?: null | number;
        meta_data?: null | {
          [k: string]: any;
        };
        group_id?: string;
        first_published_at?: string;
        release_id?: null | number;
        lang?: string;
        path?: null | string;
        alternates?: any[];
        default_full_slug?: null | string;
        translated_slugs?: null | any[];
        [k: string]: any;
      };
      [k: string]: any;
    }
  | {
      url?: string;
      cached_url?: string;
      anchor?: string;
      linktype?: "asset" | "url";
      target?: "_self" | "_blank";
      [k: string]: any;
    }
  | {
      email?: string;
      linktype?: "email";
      target?: "_self" | "_blank";
      [k: string]: any;
    };