### PR TITLE
Feat: Add `resolveLinks` option to improve MultilinkStoryblok

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Example:
 - target *optional default: storyblok-component-types.d.ts
 - titlePrefix *optional default: '_storyblok' 
 - titleSuffix *optional
+- resolveLinks *optional 
 - compilerOptions.[property] *optional
 - customTypeParser *optional - path to a custom parser NodeJS file
 ```
@@ -79,6 +80,8 @@ storyblokToTypescript({
     titlePrefix: '',
     // optional type name suffix (default: [Name]_Storyblok)
     titleSuffix: '_storyblok',
+    // optional resolveLinks (default: story)
+    resolveLinks: "url",
     // optional compilerOptions which get passed through to json-schema-to-typescript
     compilerOptions: {
         unknownAny: false,

--- a/src/genericTypes.ts
+++ b/src/genericTypes.ts
@@ -1,10 +1,10 @@
 import { JSONSchema4 } from 'json-schema';
 import { compile } from 'json-schema-to-typescript';
 
-import { BasicType, CompilerOptions } from './typings';
+import { BasicType, CompilerOptions, StoryblokResolveOptions } from './typings';
 
 const typeFuncs: {
-    [k in BasicType]: (name: string, options: CompilerOptions) => Promise<string | undefined>
+    [k in BasicType]: (name: string, options: CompilerOptions, storyblokResolve: StoryblokResolveOptions) => Promise<string | undefined>
 } = {
     'asset': generateAssetTypeIfNotYetGenerated,
     'multiasset': generateMultiAssetTypeIfNotYetGenerated,
@@ -21,8 +21,8 @@ async function compileType(obj: JSONSchema4, name: BasicType, compilerOptions: C
     return ts
 }
 
-export async function generate(type: BasicType, title: string, compilerOptions: CompilerOptions) {
-    return await typeFuncs[type](title, compilerOptions)
+export async function generate(type: BasicType, title: string, compilerOptions: CompilerOptions, storyblokResolve: StoryblokResolveOptions) {
+    return await typeFuncs[type](title, compilerOptions, storyblokResolve)
 }
 
 export const TYPES = Object.keys(typeFuncs)
@@ -154,7 +154,161 @@ async function generateMultiAssetTypeIfNotYetGenerated(title: string, compilerOp
     }
 }
 
-async function generateMultiLinkTypeIfNotYetGenerated(title: string, compilerOptions: CompilerOptions) {
+function getStoryLinkTypeByResolveLink(resolveLinkOption?: "url" | "link" | "story"): JSONSchema4 {
+    switch (resolveLinkOption) {
+        case "url":
+            return {
+                type: 'object',
+                required: ['name', 'id', 'uuid', 'slug', 'url', 'full_slug'],
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    id: {
+                        type: "integer"
+                    },
+                    uuid: {
+                        type: "string",
+                        format: "uuid"
+                    },
+                    slug: {
+                        type: "string"
+                    },
+                    url: {
+                        type: "string"
+                    },
+                    full_slug: {
+                        type: "string"
+                    }
+                }
+            }
+        case "link":
+            return {
+                type: 'object',
+                required: ['name', 'id', 'uuid', 'slug'],
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    id: {
+                        type: "integer"
+                    },
+                    uuid: {
+                        type: "string",
+                        format: "uuid"
+                    },
+                    slug: {
+                        type: "string"
+                    },
+                    position: {
+                        type: "integer"
+                    },
+                    is_folder: {
+                        type: "boolean"
+                    },
+                    is_startpage: {
+                        type: "boolean"
+                    },
+                    parent_id: {
+                        type: ["null", "integer"]
+                    },
+                    published: {
+                        type: "boolean"
+                    },
+                    path: {
+                        type: ["null", "string"]
+                    },
+                    real_path: {
+                        type: ["null", "string"]
+                    },
+                }
+            }
+        default:
+            return {
+                type: 'object',
+                required: ['name', 'id', 'uuid', 'slug', 'url', 'full_slug'],
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    created_at: {
+                        type: "string",
+                        format: "date-time"
+                    },
+                    published_at: {
+                        type: "string",
+                        format: "date-time"
+                    },
+                    id: {
+                        type: "integer"
+                    },
+                    uuid: {
+                        type: "string",
+                        format: "uuid"
+                    },
+                    content: {
+                        type: "object"
+                    },
+                    slug: {
+                        type: "string"
+                    },
+                    full_slug: {
+                        type: "string"
+                    },
+                    sort_by_date: {
+                        type: ["null", "string"],
+                        format: "date-time"
+                    },
+                    position: {
+                        type: "integer"
+                    },
+                    tag_list: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        }
+                    },
+                    is_startpage: {
+                        type: "boolean"
+                    },
+                    parent_id: {
+                        type: ["null", "integer"]
+                    },
+                    meta_data: {
+                        type: ["null", "object"]
+                    },
+                    group_id: {
+                        type: "string",
+                        format: "uuid"
+                    },
+                    first_published_at: {
+                        type: "string",
+                        format: "date-time"
+                    },
+                    release_id: {
+                        type: ["null", "integer"]
+                    },
+                    lang: {
+                        type: "string"
+                    },
+                    path: {
+                        type: ["null", "string"]
+                    },
+                    alternates: {
+                        type: "array"
+                    },
+                    default_full_slug: {
+                        type: ["null", "string"]
+                    },
+                    translated_slugs: {
+                        type: ["null", "array"]
+                    }
+                }
+            }
+    }
+}
+
+async function generateMultiLinkTypeIfNotYetGenerated(title: string, compilerOptions: CompilerOptions, storyblokResolve: StoryblokResolveOptions) {
     if (!toGenerateWhitelist.includes("multilink")) return;
     const obj: JSONSchema4 = {
         $id: '#/multilink',
@@ -180,87 +334,7 @@ async function generateMultiLinkTypeIfNotYetGenerated(title: string, compilerOpt
                         type: 'string',
                         enum: ['_self', '_blank'],
                     },
-                    story: {
-                        type: 'object',
-                        required: ['name', 'id', 'uuid', 'slug', 'full_slug'],
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            created_at: {
-                                type: "string",
-                                format: "date-time"
-                            },
-                            published_at: {
-                                type: "string",
-                                format: "date-time"
-                            },
-                            id: {
-                                type: "integer"
-                            },
-                            uuid: {
-                                type: "string",
-                                format: "uuid"
-                            },
-                            content: {
-                                type: "object"
-                            },
-                            slug: {
-                                type: "string"
-                            },
-                            full_slug: {
-                                type: "string"
-                            },
-                            sort_by_date: {
-                                type: ["null", "string"],
-                                format: "date-time"
-                            },
-                            position: {
-                                type: "integer"
-                            },
-                            tag_list: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            },
-                            is_startpage: {
-                                type: "boolean"
-                            },
-                            parent_id: {
-                                type: ["null", "integer"]
-                            },
-                            meta_data: {
-                                type: ["null", "object"]
-                            },
-                            group_id: {
-                                type: "string",
-                                format: "uuid"
-                            },
-                            first_published_at: {
-                                type: "string",
-                                format: "date-time"
-                            },
-                            release_id: {
-                                type: ["null", "integer"]
-                            },
-                            lang: {
-                                type: "string"
-                            },
-                            path: {
-                                type: ["null", "string"]
-                            },
-                            alternates: {
-                                type: "array"
-                            },
-                            default_full_slug: {
-                                type: ["null", "string"]
-                            },
-                            translated_slugs: {
-                                type: ["null", "array"]
-                            }
-                        }
-                    }
+                    story: getStoryLinkTypeByResolveLink(storyblokResolve.resolveLinks)
                 }
             },
             {

--- a/src/genericTypes.ts
+++ b/src/genericTypes.ts
@@ -1,7 +1,7 @@
 import { JSONSchema4 } from 'json-schema';
 import { compile } from 'json-schema-to-typescript';
 
-import { BasicType, CompilerOptions, StoryblokResolveOptions } from './typings';
+import { BasicType, CompilerOptions, ResolveLinkOption, StoryblokResolveOptions } from './typings';
 
 const typeFuncs: {
     [k in BasicType]: (name: string, options: CompilerOptions, storyblokResolve: StoryblokResolveOptions) => Promise<string | undefined>
@@ -154,7 +154,7 @@ async function generateMultiAssetTypeIfNotYetGenerated(title: string, compilerOp
     }
 }
 
-function getStoryLinkTypeByResolveLink(resolveLinkOption?: "url" | "link" | "story"): JSONSchema4 {
+function getStoryLinkTypeByResolveLink(resolveLinkOption: ResolveLinkOption): JSONSchema4 {
     switch (resolveLinkOption) {
         case "url":
             return {
@@ -334,7 +334,9 @@ async function generateMultiLinkTypeIfNotYetGenerated(title: string, compilerOpt
                         type: 'string',
                         enum: ['_self', '_blank'],
                     },
-                    story: getStoryLinkTypeByResolveLink(storyblokResolve.resolveLinks)
+                    ...(storyblokResolve.resolveLinks.length
+                        ? { story: { oneOf: storyblokResolve.resolveLinks.map(getStoryLinkTypeByResolveLink) } }
+                        : {}),
                 }
             },
             {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,9 +16,11 @@ export default async function storyblokToTypescript({
                                                         customTypeParser,
                                                         path = 'src/typings/generated/components-schema.ts',
                                                         titleSuffix = '_storyblok',
-                                                        titlePrefix = ''
+                                                        titlePrefix = '',
+                                                        resolveLinks = "story"
                                                     }: StoryblokTsOptions) {
 
+    const storyblokResolveOptions = { resolveLinks };
     compilerOptions = {
         unknownAny: false,
         bannerComment: '',
@@ -97,7 +99,7 @@ export default async function storyblokToTypescript({
             const type = schemaElement.type
 
             if (TYPES.includes(type)) {
-                const ts = await generate(type, getTitle(type), compilerOptions)
+                const ts = await generate(type, getTitle(type), compilerOptions, storyblokResolveOptions)
 
                 if (ts) {
                     tsString.push(ts)

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export default async function storyblokToTypescript({
                                                         path = 'src/typings/generated/components-schema.ts',
                                                         titleSuffix = '_storyblok',
                                                         titlePrefix = '',
-                                                        resolveLinks = "story"
+                                                        resolveLinks = []
                                                     }: StoryblokTsOptions) {
 
     const storyblokResolveOptions = { resolveLinks };

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -20,17 +20,20 @@ export type BasicType = 'asset' | 'multiasset' | 'multilink' | 'table' | 'richte
 
 export type CompilerOptions = Partial<Options>;
 
+export type ResolveLinkOption = "url" | "link" | "story"
+
 export interface StoryblokResolveOptions {
-    resolveLinks?: "url" | "link" | "story"
+    resolveLinks: ResolveLinkOption[]
 }
 
-export interface StoryblokTsOptions extends StoryblokResolveOptions {
+export interface StoryblokTsOptions {
     componentsJson: {
         components: JSONSchema4[]
     },
     customTypeParser?: (key: string, options: JSONSchema4) => void
     compilerOptions?: CompilerOptions
     path?: string
+    resolveLinks?: ResolveLinkOption[]
     titleSuffix?: string
     titlePrefix?: string
 }
@@ -38,6 +41,7 @@ export interface StoryblokTsOptions extends StoryblokResolveOptions {
 export interface CliOptions {
     source: string
     target?: string
+    resolveLinks?: string | string[]
     titleSuffix?: string
     titlePrefix?: string
     customTypeParser?: string

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -20,7 +20,11 @@ export type BasicType = 'asset' | 'multiasset' | 'multilink' | 'table' | 'richte
 
 export type CompilerOptions = Partial<Options>;
 
-export interface StoryblokTsOptions {
+export interface StoryblokResolveOptions {
+    resolveLinks?: "url" | "link" | "story"
+}
+
+export interface StoryblokTsOptions extends StoryblokResolveOptions {
     componentsJson: {
         components: JSONSchema4[]
     },


### PR DESCRIPTION
Handle [this options](https://www.storyblok.com/docs/guide/in-depth/rendering-the-link-field#resolving-a-link-to-a-story-with-url) from storyblok.

The code only handle the part were `resolve_links` value is `story`. In this PR, I wanted to also handle `url` and `link` value.
I think most of Storyblok's dev resolve with `url` value instead, now we have all three choices.

By default, I put `story` value to the parameter to avoid breaking changes, but I think it's not optimal. When you don't put `resolve_links` in your code, the link object won't have any object.