### PR TITLE
Add meta-fields plugin to defaultCustomParser

### DIFF
--- a/src/defaultCustomMapper.ts
+++ b/src/defaultCustomMapper.ts
@@ -2,6 +2,26 @@ import {JSONSchema4} from "json-schema";
 
 export default function defaultCustomMapper (key: string, obj: JSONSchema4) {
   switch (obj.field_type) {
+    case 'meta-fields':
+      return {
+        [key]: {
+          type: 'object',
+          properties: {
+            _uid: {
+              type: 'string'
+            },
+            title: {
+              type: 'string'
+            },
+            plugin: {
+              type: 'string'
+            },
+            description: {
+              type: 'string'
+            }
+          }
+        }
+      }
     case 'seo-metatags':
       return {
         [key]: {


### PR DESCRIPTION
The `seo-metatags` plugin is only available with a Storyblok Entry plan and has to be installed first. The `meta-fields` plugin on the other hand is one of the default plugins, available on every plan and shares the same basic fields. Therefore I suggest adding it to the `defaultCustomParser`.