### PR TITLE
fix: make option type value driven

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -222,8 +222,8 @@ export default async function storyblokToTypescript({
             options = element.options.map(item => item.value);
         }
 
-        if (options.length && element.exclude_empty_option !== true) {
-            options.unshift('')
+        if (options.length && element.exclude_empty_option === true) {
+            options = options.filter(option => option !== "")
         }
 
         // option types with source self do not have a source field but the options as array


### PR DESCRIPTION
* prevents adding an empty string that doesn't exist in the actual options

**old situation**

```ts
// pseudo code old situation
const optionValues = ["value1", "value2"]
exlucde_empty_options = false;
enum options = "" | "value1" | "value2" | "" // >> empty string not wanted, does not exist
```

**new situation**
```ts
// pseudo code new situation
const optionValues = ["value1", "value2"]
exlucde_empty_options = false;

enum options = "value1" | "value2"
```
